### PR TITLE
Add battery level icon to vacuum entity

### DIFF
--- a/custom_components/xiaomi_miot_raw/deps/const.py
+++ b/custom_components/xiaomi_miot_raw/deps/const.py
@@ -88,6 +88,7 @@ MAP = {
     "sensor": {
         "air_fryer",
         "air_monitor",
+        "battery",
         "chair",
         "chair_customize",
         "cooker",

--- a/custom_components/xiaomi_miot_raw/vacuum.py
+++ b/custom_components/xiaomi_miot_raw/vacuum.py
@@ -126,7 +126,8 @@ class MiotVacuum(GenericMiotDevice, StateVacuumEntity):
             s |= SUPPORT_STOP
         if self._did_prefix + 'mode' in self._mapping:
             s |= SUPPORT_FAN_SPEED
-        if self._did_prefix + 'battery_level' in self._mapping:
+        if self._did_prefix + 'battery_level' in self._mapping or \
+            'battery_battery_level' in self._mapping:
             s |= SUPPORT_BATTERY
         if 'a_l_battery_start_charge' in self._mapping:
             s |= SUPPORT_RETURN_HOME
@@ -231,6 +232,7 @@ class MiotVacuum(GenericMiotDevice, StateVacuumEntity):
         except:
             pass
         try:
-            self._battery_level = self._state_attrs.get(self._did_prefix + 'battery_level')
+            self._battery_level = self._state_attrs.get(self._did_prefix + 'battery_level') or \
+                self._state_attrs.get('battery_battery_level')
         except:
             pass

--- a/custom_components/xiaomi_miot_raw/vacuum.py
+++ b/custom_components/xiaomi_miot_raw/vacuum.py
@@ -126,7 +126,7 @@ class MiotVacuum(GenericMiotDevice, StateVacuumEntity):
             s |= SUPPORT_STOP
         if self._did_prefix + 'mode' in self._mapping:
             s |= SUPPORT_FAN_SPEED
-        if 'battery_battery_level' in self._mapping:
+        if self._did_prefix + 'battery_level' in self._mapping:
             s |= SUPPORT_BATTERY
         if 'a_l_battery_start_charge' in self._mapping:
             s |= SUPPORT_RETURN_HOME
@@ -228,5 +228,9 @@ class MiotVacuum(GenericMiotDevice, StateVacuumEntity):
             for k,v in STATE_MAPPING.items():
                 if self._state_attrs.get(self._did_prefix + 'status') in v:
                     self._state = k
+        except:
+            pass
+        try:
+            self._battery_level = self._state_attrs.get(self._did_prefix + 'battery_level')
         except:
             pass


### PR DESCRIPTION
Displays battery level in vacuum entity card. Based off of `battery_level` property

![image](https://user-images.githubusercontent.com/5904370/130820954-ed63dd36-3fcd-4311-9489-6a18d2f82a00.png)
