### PR TITLE
fix(toilet) support properties in function

### DIFF
--- a/custom_components/xiaomi_miot_raw/deps/const.py
+++ b/custom_components/xiaomi_miot_raw/deps/const.py
@@ -177,6 +177,7 @@ MAP = {
         "fan_control",
         "dryer",
         "toilet",
+        "function",
         "settings",
         "settings_2",
         "air_fresh_heater",


### PR DESCRIPTION
智能马桶一体机把部分属性放到了了 `function` 这个sid下，如[智米M1](https://home.miot-spec.com/spec/zhimi.toilet.pa2) 