### PR TITLE
请求api返回小米账号登录信息失效时，自动重新登陆

### DIFF
--- a/custom_components/xiaomi_miot_raw/__init__.py
+++ b/custom_components/xiaomi_miot_raw/__init__.py
@@ -195,6 +195,7 @@ async def async_remove_entry(hass, entry):
 async def _setup_micloud_entry(hass, config_entry):
     """Thanks to @AlexxIT """
     data: dict = config_entry.data.copy()
+    hass.data[DOMAIN]['micloud_config'] = data
     server_location = data.get('server_location') or 'cn'
 
     session = aiohttp_client.async_create_clientsession(hass, auto_cleanup=False)

--- a/custom_components/xiaomi_miot_raw/basic_dev_class.py
+++ b/custom_components/xiaomi_miot_raw/basic_dev_class.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 import logging
-from datetime import timedelta
+from datetime import timedelta, datetime
 from functools import partial
 from dataclasses import dataclass
 
@@ -62,7 +62,9 @@ UPDATE_BETA_FLAG = False
 
 class GenericMiotDevice(Entity):
     """通用 MiOT 设备"""
-
+    
+    lastAutoUpdateAccountTime=datetime.now()-timedelta(seconds=3600)
+    
     def __init__(self, device, config, device_info, hass = None, mi_type = None):
         """Initialize the entity."""
 
@@ -506,7 +508,56 @@ class GenericMiotDevice(Entity):
                         statedict[key] = pre_process_data(key, dict1[value['siid']][value['piid']])
 
                 else:
-                    pass
+                    # auth err
+                    # 小米账号登录信息失效
+                    # 自动重新登录，间隔3600秒
+                    lostTime=(datetime.now()-GenericMiotDevice.lastAutoUpdateAccountTime).total_seconds()
+                    _LOGGER.debug("miaccount auth err:lostTime:%d" % (lostTime))
+                    if (lostTime>3600):
+                        _LOGGER.warning("auto update mi_account token")
+                        GenericMiotDevice.lastAutoUpdateAccountTime=datetime.now()
+                    
+                        config=self.hass.data[DOMAIN]['micloud_config']
+                        #_LOGGER.debug(f"self.hass.data[DOMAIN]['config']: {json.dumps (config)}")
+                        if 'username' in config:
+                            cloud=self._cloud_instance
+                            resp = await cloud.login(config['username'],
+                                                config['password'])
+                            if resp == (0, None):
+                                #让新 token 实时生效
+                                for item in self.hass.data[DOMAIN]['cloud_instance_list']:
+                                  mc = item['cloud_instance']
+                                  mc.login_by_credientals(
+                                    cloud.auth["user_id"],
+                                    cloud.auth['service_token'],
+                                    cloud.auth['ssecurity']
+                                  )
+                        
+                                if self.hass.config_entries.async_entries(DOMAIN):  #更新每个设备的token
+                                  _LOGGER.warning("Found existing config entries")
+                                  for entry in self.hass.config_entries.async_entries(DOMAIN):
+                                    if (
+                                      entry.data.get("update_from_cloud")
+                                    ):
+                                      _LOGGER.warning("Updating existing entry")
+                                      update_from_cloud=entry.data.get("update_from_cloud")
+                                      update_from_cloud_new={
+                                         "did": update_from_cloud["did"],
+                                         "userId": update_from_cloud["userId"],
+                                         "serviceToken": cloud.auth['service_token'],
+                                         "ssecurity": cloud.auth['ssecurity'],
+                                         "server_location": update_from_cloud["server_location"]
+                                      }
+                                      entry_data_new=dict(entry.data)
+                                      entry_data_new.update({"update_from_cloud":update_from_cloud_new})
+                                      entry_id = entry.entry_id
+                                      self.hass.data[DOMAIN]['configs'][entry_id] = entry_data_new 
+                                      self.hass.config_entries.async_update_entry(  #保存新token到文件
+                                        entry,
+                                        data=entry_data_new,
+                                     )
+                            else: 
+                                _LOGGER.error("config.data no username")
 
             self._fail_count = 0
             self._state_attrs.update(statedict)

--- a/custom_components/xiaomi_miot_raw/deps/xiaomi_cloud_new.py
+++ b/custom_components/xiaomi_miot_raw/deps/xiaomi_cloud_new.py
@@ -216,7 +216,7 @@ class MiCloud:
                 'signature': signature,
                 '_nonce': nonce,
                 'data': data
-            }, timeout=5)
+            }, timeout=30)
 
             self._fail_count = 0
             resp = await r.json(content_type=None)

--- a/custom_components/xiaomi_miot_raw/deps/xiaomi_cloud_new.py
+++ b/custom_components/xiaomi_miot_raw/deps/xiaomi_cloud_new.py
@@ -78,6 +78,7 @@ class MiCloud:
                 'ssecurity': data['ssecurity'],
                 'service_token': token
             }
+            _LOGGER.info(f"user_id:{data['userId']},service_token: {token}")
             return (0, None)
 
         except Exception as e:
@@ -160,6 +161,7 @@ class MiCloud:
         except Exception:
             loc = "en_US"
         try:
+            _LOGGER.info(f"user_id:{self.auth['user_id']},token:{self.auth['service_token']}")
             r = await self.session.post(baseurl + url, cookies={
                 'userId': self.auth['user_id'],
                 'serviceToken': self.auth['service_token'],
@@ -171,7 +173,7 @@ class MiCloud:
                 'signature': signature,
                 '_nonce': nonce,
                 'data': data
-            }, timeout=5)
+            }, timeout=30)
 
             resp = await r.json(content_type=None)
             assert resp['code'] == 0, resp
@@ -203,6 +205,7 @@ class MiCloud:
             'cache-control': "no-cache",
         }
         try:
+            _LOGGER.info(f"user_id:{self.auth['user_id']},token:{self.auth['service_token']}")
             r = await self.session.post(url, cookies={
                 'userId': self.auth['user_id'],
                 'serviceToken': self.auth['service_token'],
@@ -230,6 +233,7 @@ class MiCloud:
                 return resp
 
         except (asyncio.TimeoutError, ClientConnectorError) as ex:
+            _LOGGER.exception("request_miot_api:")
             if self._fail_count < 3 and api == "/miotspec/prop/get":
                 self._fail_count += 1
                 _LOGGER.info(f"Error while requesting MIoT api {api} : {ex} ({self._fail_count})")


### PR DESCRIPTION
解决隔段时间，小米账号的token失效的问题
增加判断返回账号失效时，自动发起重登录，并刷新所有设备的token
默认3600秒内只自动登陆一次
主要由三处改动
1、在界面手动更新小米账号密码时，刷新所有设备token
2、米家api接口超时由5秒改为30秒
3、增加判断返回账号失效时，自动发起重登录，并刷新所有设备的token